### PR TITLE
Supports  LAMBDA_PROXY integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ serverlessOption := {
             path: String,
             method: String,
             uriLambdaAlias: String = "${stageVariables.env}",
+            proxyIntegration: Boolean = false,
             cors: Boolean = false,
             `private`: Boolean = false,
             authorizerName: Option[String] = None,
@@ -185,6 +186,7 @@ lazy val root = (project in file(".")).
               HttpEvent(
                 path = "/hellos",
                 method = "GET",
+                proxyIntegration = false,
                 cors = true,
                 authorizerName = (name in auth).value,
                 invokeInput = HttpInvokeInput(

--- a/src/main/scala/com/github/yoshiyoshifujii/aws/apigateway/AWSApiGatewayMethods.scala
+++ b/src/main/scala/com/github/yoshiyoshifujii/aws/apigateway/AWSApiGatewayMethods.scala
@@ -8,6 +8,7 @@ import scala.util.Try
 
 trait AWSApiGatewayMethodsWrapper extends AWSApiGatewayRestApiWrapper {
   val restApiId: RestApiId
+  val integrationType: IntegrationType
   val path: Path
   val httpMethod: HttpMethod
 
@@ -16,7 +17,7 @@ trait AWSApiGatewayMethodsWrapper extends AWSApiGatewayRestApiWrapper {
       .withRestApiId(restApiId)
       .withResourceId(resourceId)
       .withHttpMethod(httpMethod)
-      .withType(IntegrationType.AWS)
+      .withType(integrationType)
       .withIntegrationHttpMethod("POST")
       .withUri(uri.value)
       .withRequestTemplates(requestTemplates.toMap)
@@ -178,6 +179,7 @@ trait AWSApiGatewayMethodsWrapper extends AWSApiGatewayRestApiWrapper {
   def enableCORS(resourceId: ResourceId) = {
     val om = AWSApiGatewayMethods(regionName = this.regionName,
                                   restApiId = this.restApiId,
+                                  integrationType = this.integrationType,
                                   path = this.path,
                                   httpMethod = "OPTIONS")
     for {
@@ -290,6 +292,7 @@ trait AWSApiGatewayMethodsWrapper extends AWSApiGatewayRestApiWrapper {
 
 case class AWSApiGatewayMethods(regionName: String,
                                 restApiId: RestApiId,
+                                integrationType: IntegrationType,
                                 path: Path,
                                 httpMethod: HttpMethod)
     extends AWSApiGatewayMethodsWrapper

--- a/src/main/scala/com/github/yoshiyoshifujii/aws/serverless/keys/DeployResource.scala
+++ b/src/main/scala/com/github/yoshiyoshifujii/aws/serverless/keys/DeployResource.scala
@@ -1,5 +1,6 @@
 package com.github.yoshiyoshifujii.aws.serverless.keys
 
+import com.amazonaws.services.apigateway.model.IntegrationType
 import com.github.yoshiyoshifujii.aws.apigateway.{
   AWSApiGatewayAuthorize,
   AWSApiGatewayMethods,
@@ -15,10 +16,14 @@ trait DeployResource extends KeysBase {
                                lambdaSuffix: String,
                                publishedVersion: Option[String],
                                httpEvent: HttpEvent) = {
-    val method = AWSApiGatewayMethods(regionName = so.provider.region,
-                                      restApiId = restApiId,
-                                      path = httpEvent.path,
-                                      httpMethod = httpEvent.method)
+    val method = AWSApiGatewayMethods(
+      regionName = so.provider.region,
+      restApiId = restApiId,
+      integrationType =
+        if (httpEvent.proxyIntegration) IntegrationType.AWS_PROXY else IntegrationType.AWS,
+      path = httpEvent.path,
+      httpMethod = httpEvent.method
+    )
 
     for {
       resourceOpt <- method.deploy(

--- a/src/main/scala/serverless/Event.scala
+++ b/src/main/scala/serverless/Event.scala
@@ -11,6 +11,7 @@ trait Event
 case class HttpEvent(path: String,
                      method: String,
                      uriLambdaSuffix: Option[String] = Some("${stageVariables.env}"),
+                     proxyIntegration: Boolean = false,
                      cors: Boolean = false,
                      `private`: Boolean = false,
                      authorizerName: Option[String] = None,


### PR DESCRIPTION
Add [LAMBDA_PROXY](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html) integration support.

Enabling Lambda proxy integration if specified  `proxyIntegration` property to `true`.(Default `false`)