### PR TITLE
Supports Function Level Concurrent Execution Limit

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsSdkVersion = "1.11.123"
+  val awsSdkVersion = "1.11.313"
   val awsJavaSdkLambda      = "com.amazonaws" % "aws-java-sdk-lambda"      % awsSdkVersion
   val awsJavaSdkApiGateway  = "com.amazonaws" % "aws-java-sdk-api-gateway" % awsSdkVersion
   val awsJavaSdkS3          = "com.amazonaws" % "aws-java-sdk-s3"          % awsSdkVersion

--- a/src/main/scala/com/github/yoshiyoshifujii/aws/lambda/AWSLambda.scala
+++ b/src/main/scala/com/github/yoshiyoshifujii/aws/lambda/AWSLambda.scala
@@ -38,6 +38,7 @@ trait AWSLambdaWrapper extends AWSWrapper {
              timeout: Option[Timeout],
              memorySize: Option[MemorySize],
              environment: Option[Map[String, String]],
+             reservedConcurrentExecutions: Option[Int],
              tags: Option[Map[String, String]],
              tracingMode: Option[TracingMode]) = {
     val code = new FunctionCode()
@@ -58,7 +59,23 @@ trait AWSLambdaWrapper extends AWSWrapper {
         tags.foreach(t => request.setTags(t.asJava))
         tracingMode.foreach(m => request.setTracingConfig(new TracingConfig().withMode(m)))
 
-        client.createFunction(request)
+        val createdFunction = client.createFunction(request)
+
+        reservedConcurrentExecutions match {
+          case Some(execs) =>
+            client.putFunctionConcurrency(
+              new PutFunctionConcurrencyRequest()
+                .withFunctionName(functionName)
+                .withReservedConcurrentExecutions(execs)
+            )
+          case None =>
+            client.deleteFunctionConcurrency(
+              new DeleteFunctionConcurrencyRequest()
+                .withFunctionName(functionName)
+            )
+        }
+
+        createdFunction
       }
     } yield cf
   }
@@ -90,6 +107,7 @@ trait AWSLambdaWrapper extends AWSWrapper {
                    timeout: Option[Timeout],
                    memorySize: Option[MemorySize],
                    environment: Option[Map[String, String]],
+                   reservedConcurrentExecutions: Option[Int],
                    tracingMode: Option[TracingMode]) = Try {
     val request = new UpdateFunctionConfigurationRequest()
       .withFunctionName(functionName)
@@ -102,7 +120,23 @@ trait AWSLambdaWrapper extends AWSWrapper {
     environment.foreach(e => request.setEnvironment(new Environment().withVariables(e.asJava)))
     tracingMode.foreach(m => request.setTracingConfig(new TracingConfig().withMode(m)))
 
-    client.updateFunctionConfiguration(request)
+    val updatedFunction = client.updateFunctionConfiguration(request)
+
+    reservedConcurrentExecutions match {
+      case Some(execs) =>
+        client.putFunctionConcurrency(
+          new PutFunctionConcurrencyRequest()
+            .withFunctionName(functionName)
+            .withReservedConcurrentExecutions(execs)
+        )
+      case None =>
+        client.deleteFunctionConcurrency(
+          new DeleteFunctionConcurrencyRequest()
+            .withFunctionName(functionName)
+        )
+    }
+
+    updatedFunction
   }
 
   def tagResource(functionArn: FunctionArn, tags: Map[String, String]) = Try {
@@ -169,6 +203,7 @@ trait AWSLambdaWrapper extends AWSWrapper {
              timeout: Option[Timeout],
              memorySize: Option[MemorySize],
              environment: Option[Map[String, String]],
+             reservedConcurrentExecutions: Option[Int],
              tags: Option[Map[String, String]],
              tracingMode: Option[TracingMode],
              createAfter: FunctionArn => Try[Any] = _ => Try()) = {
@@ -185,6 +220,7 @@ trait AWSLambdaWrapper extends AWSWrapper {
             timeout = timeout,
             memorySize = memorySize,
             environment = environment,
+            reservedConcurrentExecutions = reservedConcurrentExecutions,
             tracingMode = tracingMode
           )
           _ <- tags map { t =>
@@ -203,6 +239,7 @@ trait AWSLambdaWrapper extends AWSWrapper {
             timeout = timeout,
             memorySize = memorySize,
             environment = environment,
+            reservedConcurrentExecutions = reservedConcurrentExecutions,
             tags = tags,
             tracingMode = tracingMode
           )

--- a/src/main/scala/com/github/yoshiyoshifujii/aws/serverless/keys/DeployFunction.scala
+++ b/src/main/scala/com/github/yoshiyoshifujii/aws/serverless/keys/DeployFunction.scala
@@ -32,6 +32,7 @@ trait DeployFunctionBase extends KeysBase {
         timeout = Option(function.timeout),
         memorySize = Option(function.memorySize),
         environment = Option(function.getEnvironment(stage)),
+        reservedConcurrentExecutions = function.reservedConcurrentExecutions,
         tags = if (function.tags.nonEmpty) Some(function.tags) else None,
         tracingMode = function.tracing.map(_.value),
         createAfter = arn => lambda.addPermission(arn)

--- a/src/main/scala/serverless/package.scala
+++ b/src/main/scala/serverless/package.scala
@@ -49,6 +49,7 @@ package object serverless {
                       timeout: Int = 10,
                       role: String,
                       environment: Map[String, String] = Map.empty,
+                      reservedConcurrentExecutions: Option[Int] = None,
                       tags: Map[String, String] = Map.empty,
                       tracing: Option[Tracing] = None,
                       events: Events = Events.empty)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.1.0.b2-SNAPSHOT"
+version in ThisBuild := "3.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.0-SNAPSHOT"
+version in ThisBuild := "3.1.0.b"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.1.0.b"
+version in ThisBuild := "3.1.0.b2-SNAPSHOT"


### PR DESCRIPTION
Add `reservedConcurrentExecutions` parameter to `Function`.

```scala
Function(
    :
  reservedConcurrentExecutions = Some(10)
)
```

* About function level concurrent executon.
https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html#per-function-concurrency

* Require version up AWS SDK.
